### PR TITLE
ci(release): pin node to LTS to avoid undici break

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
-          node-version: "latest" # does not matter for our needs
+          node-version: "lts/*" # pin to LTS; Node 26's undici breaks octokit/semantic-release
 
       - uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6.1.0
         with:


### PR DESCRIPTION
## Problem

The **Cut Release** workflow fails in `semantic-release`'s `verifyConditions` step:

```
InvalidArgumentError: invalid onRequestStart method
  ... TypeError: fetch failed
  ... HttpError: invalid onRequestStart method (status 500)
```

## Root cause

`.github/workflows/release.yaml` pinned `actions/setup-node` to `node-version: "latest"`, which resolved to **Node.js 26** on the runner (confirmed by the error's user-agent: `@semantic-release/github v12.0.8 octokit-core.js/7.0.6 Node.js/26`).

Node 26 bundles a newer **undici** whose request-dispatcher interceptor API changed and now rejects the `onRequestStart` interceptor that octokit/semantic-release registers. Every outbound `fetch` (e.g. `GET /repos/tigrisdata/objgit`) throws before reaching the GitHub API, killing the job.

This is a Node/undici version incompatibility — not a token, permissions, or release-config problem.

## Fix

Pin to `lts/*` (currently the Node 24 line), which ships an undici compatible with the octokit stack.

## Verification

Re-run the **Cut Release** workflow via `workflow_dispatch` and confirm the *Setup Node* step shows Node 24.x and `semantic-release --debug` gets past `verifyConditions` without the `onRequestStart` error.