### PR TITLE
chore: use Go version stamping

### DIFF
--- a/cmd/objgitd/main.go
+++ b/cmd/objgitd/main.go
@@ -20,12 +20,13 @@ import (
 	"github.com/gliderlabs/ssh"
 	"github.com/go-git/go-git/v6/plumbing/transport"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/tigrisdata/storage-go"
-	"golang.org/x/sync/errgroup"
+	"github.com/tigrisdata/objgit"
 	"github.com/tigrisdata/objgit/internal"
 	"github.com/tigrisdata/objgit/internal/auth"
 	"github.com/tigrisdata/objgit/internal/metrics"
 	"github.com/tigrisdata/objgit/internal/s3fs"
+	"github.com/tigrisdata/storage-go"
+	"golang.org/x/sync/errgroup"
 
 	_ "github.com/joho/godotenv/autoload"
 )
@@ -141,6 +142,7 @@ func main() {
 	}
 
 	slog.Info("objgitd listening",
+		"version", objgit.Version,
 		"git_bind", *gitBind,
 		"http_bind", *httpBind,
 		"ssh_bind", *sshBind,

--- a/objgit.go
+++ b/objgit.go
@@ -1,0 +1,14 @@
+package objgit
+
+import "runtime/debug"
+
+func init() {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+
+	Version = bi.Main.Version
+}
+
+var Version = "(devel)"


### PR DESCRIPTION
## Summary

Use [Go's native version stamping](https://michael.stapelberg.ch/posts/2026-04-05-stamp-it-all-programs-must-report-their-version/) to embed a version number into the program.

## Details

Minimal change. Only changes log output.

## Test plan

- [x] Code compiles with `go build ./...`
- [x] Code formatted with `npm run format`
- [x] Manual testing
